### PR TITLE
Move babel-eslint dependency to global

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation
 
 Install global dependencies (if you haven't already)
 
-    $ npm install -g webpack karma-cli
+    $ npm install -g webpack karma-cli babel-eslint
     $ npm install
 
 Testing

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "babel-core": "5.2.15",
-    "babel-eslint": "3.0.1",
     "babel-loader": "5.0.0",
     "eslint": "0.20.0",
     "jasmine": "2.3.1",


### PR DESCRIPTION
Per http://eslint.org/docs/user-guide/configuring.html#specifying-parser, the `parser` field in `.eslintrc` should point to a global node module. Maybe I'm missing something obvious, but it doesn't work for me without this change.
